### PR TITLE
⚙️ [Maintenance]: Add afterall to codespell ignore words list

### DIFF
--- a/.github/linters/.codespellrc
+++ b/.github/linters/.codespellrc
@@ -1,2 +1,3 @@
 [codespell]
 skip = ./.github/linters
+ignore-words-list = afterall


### PR DESCRIPTION
Adds `afterall` to the codespell ignore words list in `.codespellrc` to prevent false positive spell check warnings in CI linting. This term is commonly used in PowerShell (e.g., Pester's `AfterAll` block) and should not be flagged as a misspelling.

## Codespell configuration

The `.codespellrc` linter configuration now includes `ignore-words-list = afterall`, which tells codespell to skip this word during spell checking. No changes to functionality or shipped artifacts.