### PR TITLE
📖 [Docs]: Document `Version` input accepts NuGet version ranges

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
     default: 'false'
   Version:
-    description: Specifies the version of the GitHub module to be installed. The value must be an exact version.
+    description: Specifies the version of the GitHub module to be installed. Accepts an exact version or a NuGet version range (for example '[1.2.0, 2.0.0)').
     required: false
   Prerelease:
     description: Allow prerelease versions if available.


### PR DESCRIPTION
GitHub-Script v1.9.0 (already on `main`) expanded the passed-through `Version` input to accept a NuGet version range in addition to an exact version. This updates the `Version` input documentation so consumers know ranges are supported.

## Changed: `Version` input documentation

The `Version` input description in `action.yml` (and the README input table, where present) now states that it accepts an exact version or a NuGet version range (for example `[1.2.0, 2.0.0)`), instead of claiming the value must be an exact version.

## Technical Details

Documentation-only; no behavior change. The action already installs the `GitHub` module via GitHub-Script v1.9.0, which resolves NuGet version ranges. Mirrors the fix applied in PSModule/Release-GHRepository#106.
